### PR TITLE
disable github version checks

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -55,7 +55,7 @@ export function startup() {
   process.on('SIGINT', () => {
     process.exit(1);
   });
-  versionChecker();
+  // versionChecker();
 }
 
 export function cliInputs() {


### PR DESCRIPTION
Disable github version checks. We were getting rate limited by Github API.

```
   host: 'api.github.com',
    protocol: 'https:',
    _redirectable: Writable {
      _writableState: [WritableState],
      _events: [Object: null prototype],
      _eventsCount: 3,
      _maxListeners: undefined,
      _options: [Object],
      _ended: true,
      _ending: true,
      _redirectCount: 0,
      _redirects: [],
      _requestBodyLength: 0,
      _requestBodyBuffers: [],
      _onNativeResponse: [Function (anonymous)],
      _currentRequest: [Circular *1],
      _currentUrl: 'https://api.github.com/repos/SwapnilSoni1999/spotify-dl/tags',
      [Symbol(kCapture)]: false
    },
    [Symbol(kCapture)]: false,
    [Symbol(kBytesWritten)]: 0,
    [Symbol(kEndCalled)]: true,
    [Symbol(kNeedDrain)]: false,
    [Symbol(corked)]: 0,
    [Symbol(kOutHeaders)]: [Object: null prototype] {
      accept: [Array],
      'user-agent': [Array],
      host: [Array]
    },
    [Symbol(errored)]: null,
    [Symbol(kUniqueHeaders)]: null
  },
  data: `{"message":"API rate limit exceeded for 199.241.136.97. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}\n`
}
```